### PR TITLE
Update 80probe.py for Python 3+

### DIFF
--- a/80probe.py
+++ b/80probe.py
@@ -17,7 +17,7 @@ class Probe80(object):
 	def __call__(self):
 		try:
 			r = requests.get(self.url, timeout=self.timeout)
-		except Exception, e:
+		except Exception as e:
 			return
 
 		self.content = r.text


### PR DESCRIPTION
Python 3.6.1 does not like like 20

  File "./80probe.py", line 20
    except Exception, e:
                    ^
SyntaxError: invalid syntax

changed from "except Exception, e:" to "except Exception as e:" and it works perfectly.